### PR TITLE
fix: remove @ts-ignore by declaring global Window.toastManager type

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,1 +1,8 @@
 export {};
+declare global {
+  interface Window {
+    toastManager?: {
+      clear: () => void;
+    };
+  }
+}

--- a/src/components/toast-container.cy.tsx
+++ b/src/components/toast-container.cy.tsx
@@ -3,6 +3,7 @@ import { toast } from '../core/toast';
 
 describe('ToastContainer Component', () => {
   beforeEach(() => {
+    // Clear any existing toasts before each test
     cy.window().then((win) => {
       if (win.toastManager) {
         win.toastManager.clear();

--- a/src/components/toast-container.cy.tsx
+++ b/src/components/toast-container.cy.tsx
@@ -3,11 +3,8 @@ import { toast } from '../core/toast';
 
 describe('ToastContainer Component', () => {
   beforeEach(() => {
-    // Clear any existing toasts before each test
     cy.window().then((win) => {
-      // @ts-ignore
       if (win.toastManager) {
-        // @ts-ignore
         win.toastManager.clear();
       }
     });


### PR DESCRIPTION
## Overview

This PR removes unnecessary `@ts-ignore` comments from the `ToastContainer` Cypress tests by adding a proper global type declaration for `window.toastManager`.

By extending the `Window` interface, we ensure that TypeScript recognizes `toastManager` as a valid property on the global `window` object. This makes the tests type-safe and removes the need for suppressing type checks.

### Changes
- Added a global declaration for `Window.toastManager` in `commands.d.ts`
- Removed `@ts-ignore` comments from the Cypress test setup
- Ensured that Cypress tests use the `toastManager` property safely with TypeScript

This keeps the test code clean, type-safe, and easier to maintain.